### PR TITLE
feat: add optional Umami analytics support

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -79,3 +79,12 @@ SMTP_SECURE=false
 SMTP_FROM=
 SMTP_REPLY_TO=
 APP_URL=http://localhost:3000
+
+# ============================================
+# Analytics (optional)
+# ============================================
+# Self-hosted Umami analytics. Set both to enable tracking.
+# Privacy-friendly, GDPR-compliant, no cookies.
+# https://umami.is/
+UMAMI_URL=
+UMAMI_WEBSITE_ID=

--- a/app/nuxt.config.ts
+++ b/app/nuxt.config.ts
@@ -56,9 +56,6 @@ export default defineNuxtConfig({
       // Voice feature flags
       voiceEnabled: process.env["VOICE_ENABLED"] !== "false",
       voiceFreeLimit: parseInt(process.env["VOICE_FREE_LIMIT"] || "50", 10),
-      // Analytics (optional) - set UMAMI_URL and UMAMI_WEBSITE_ID to enable
-      umamiUrl: process.env["UMAMI_URL"] || "",
-      umamiWebsiteId: process.env["UMAMI_WEBSITE_ID"] || "",
     },
   },
 

--- a/app/nuxt.config.ts
+++ b/app/nuxt.config.ts
@@ -56,6 +56,9 @@ export default defineNuxtConfig({
       // Voice feature flags
       voiceEnabled: process.env["VOICE_ENABLED"] !== "false",
       voiceFreeLimit: parseInt(process.env["VOICE_FREE_LIMIT"] || "50", 10),
+      // Analytics (optional) - set UMAMI_URL and UMAMI_WEBSITE_ID to enable
+      umamiUrl: process.env["UMAMI_URL"] || "",
+      umamiWebsiteId: process.env["UMAMI_WEBSITE_ID"] || "",
     },
   },
 
@@ -146,6 +149,16 @@ export default defineNuxtConfig({
         { rel: "icon", type: "image/png", href: "/favicon.png" },
         { rel: "apple-touch-icon", href: "/icons/icon-192.png" },
       ],
+      // Optional analytics - configured via UMAMI_URL and UMAMI_WEBSITE_ID env vars
+      script: process.env["UMAMI_URL"] && process.env["UMAMI_WEBSITE_ID"]
+        ? [
+            {
+              src: process.env["UMAMI_URL"],
+              defer: true,
+              "data-website-id": process.env["UMAMI_WEBSITE_ID"],
+            },
+          ]
+        : [],
     },
   },
 

--- a/docs/ENVIRONMENTS.md
+++ b/docs/ENVIRONMENTS.md
@@ -115,13 +115,26 @@ volumes:
 
 ### Environment Variables
 
-| Variable        | Required    | Default                 | Purpose                     |
-| --------------- | ----------- | ----------------------- | --------------------------- |
-| `DATABASE_URL`  | No          | `file:/data/db.sqlite`  | Database path               |
-| `NODE_ENV`      | No          | `production`            | Environment mode            |
-| `APP_URL`       | Recommended | `http://localhost:3000` | Public URL for emails/links |
-| `VOICE_ENABLED` | No          | `true`                  | Enable voice input          |
-| `GROQ_API_KEY`  | No          | -                       | Voice transcription API     |
+| Variable            | Required    | Default                 | Purpose                              |
+| ------------------- | ----------- | ----------------------- | ------------------------------------ |
+| `DATABASE_URL`      | No          | `file:/data/db.sqlite`  | Database path                        |
+| `NODE_ENV`          | No          | `production`            | Environment mode                     |
+| `APP_URL`           | Recommended | `http://localhost:3000` | Public URL for emails/links          |
+| `VOICE_ENABLED`     | No          | `true`                  | Enable voice input                   |
+| `GROQ_API_KEY`      | No          | -                       | Voice transcription API              |
+| `UMAMI_URL`         | No          | -                       | Umami analytics script URL           |
+| `UMAMI_WEBSITE_ID`  | No          | -                       | Umami website ID for tracking        |
+
+#### Analytics (Optional)
+
+To enable [Umami](https://umami.is/) analytics, set both environment variables:
+
+```bash
+UMAMI_URL=https://your-umami-instance.com/script.js
+UMAMI_WEBSITE_ID=your-website-uuid
+```
+
+This is optional and privacy-friendly — no data is collected unless you configure it.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds optional [Umami](https://umami.is/) analytics support via environment variables.

## Changes

- **nuxt.config.ts**: Adds conditional script injection when `UMAMI_URL` and `UMAMI_WEBSITE_ID` are set
- **docs/ENVIRONMENTS.md**: Documents the new environment variables

## Usage

Set both environment variables to enable tracking:

```bash
UMAMI_URL=https://your-umami-instance.com/script.js
UMAMI_WEBSITE_ID=your-website-uuid
```

## Privacy

- **Opt-in only**: No analytics code is loaded unless explicitly configured
- **Self-hosted friendly**: Works with any Umami instance
- **GDPR-compliant**: Umami is privacy-focused and doesn't use cookies for tracking